### PR TITLE
Add `ReportContext` to avoid prop drilling

### DIFF
--- a/src/components/DetailsTable.tsx
+++ b/src/components/DetailsTable.tsx
@@ -14,22 +14,22 @@ export const DetailsTable = ({
 } & Partial<TableProps>) => {
   const context = React.useContext(ReportContext);
   const data = React.useMemo(() => {
-    const files = fileRecords || context?.data.filerecords || [];
+    const files = fileRecords || context?.reportData.filerecords || [];
     return files
       .map(({ file, auditrecords }) =>
         (auditrecords ?? []).map(({ auditinfo }) => ({ fileId: file?.identifier, ...auditinfo }))
       )
       .flat();
-  }, [fileRecords, context?.data.filerecords]);
+  }, [fileRecords, context?.reportData.filerecords]);
 
   const getFileNameFromId = React.useCallback(
     (id?: string) => {
-      const filesInfo = sourceFilesInfo || context?.data.sourceFilesInfo;
+      const filesInfo = sourceFilesInfo || context?.reportData.sourceFilesInfo;
       return filesInfo?.fileId === id
         ? filesInfo?.fileName
         : filesInfo?.Files?.find((file) => file.fileId === id)?.fileName;
     },
-    [sourceFilesInfo, context?.data.sourceFilesInfo]
+    [sourceFilesInfo, context?.reportData.sourceFilesInfo]
   );
 
   const columns: Column<Partial<typeof data[number]>>[] = React.useMemo(

--- a/src/components/FilesTable.tsx
+++ b/src/components/FilesTable.tsx
@@ -13,9 +13,9 @@ export const FilesTable = ({
 }: { sourceFilesInfo?: SourceFilesInfo } & Partial<TableProps>) => {
   const context = React.useContext(ReportContext);
   const data = React.useMemo(() => {
-    const filesInfo = sourceFilesInfo || context?.data.sourceFilesInfo;
+    const filesInfo = sourceFilesInfo || context?.reportData.sourceFilesInfo;
     return [{ ...filesInfo }, ...(filesInfo?.Files ?? [])];
-  }, [sourceFilesInfo, context?.data.sourceFilesInfo]);
+  }, [sourceFilesInfo, context?.reportData.sourceFilesInfo]);
 
   const columns = React.useMemo(
     () => [

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -9,7 +9,7 @@ type _TabName = 'files' | 'details';
 
 export const ReportContext = React.createContext<
   | {
-      data: ReportData;
+      reportData: ReportData;
       currentTab: _TabName;
       setCurrentTab: (tab: _TabName | ((prev: _TabName) => _TabName)) => void;
     }
@@ -20,7 +20,7 @@ export const Report = ({ data }: { data: ReportData }) => {
   const [selectedTab, setSelectedTab] = React.useState<_TabName>('files');
 
   return (
-    <ReportContext.Provider value={{ data: data, currentTab: selectedTab, setCurrentTab: setSelectedTab }}>
+    <ReportContext.Provider value={{ reportData: data, currentTab: selectedTab, setCurrentTab: setSelectedTab }}>
       <div className='isr-report-main'>
         <div className='isr-report-tabs-wrapper'>
           <HorizontalTabs


### PR DESCRIPTION
Added `ReportContext` containing the data and the current tab state (including the setter). This will allow the children to access that info without needing to use props.

However, I still left the ability to use props so that it's possible to use the subcomponents without the parent `Report` and also to do overrides if needed. This is achieved by preferring prop value and using context value as fallback.

Also added missing default exports to each component.