### PR TITLE
Info Icon Tooltip Fix

### DIFF
--- a/src/components/utils/ClampWithTooltip.tsx
+++ b/src/components/utils/ClampWithTooltip.tsx
@@ -28,7 +28,7 @@ export const ClampWithTooltip = ({
         {children}
       </span>
       {isOverflowing && (
-        <Tooltip content={children}>
+        <Tooltip content={children} appendTo={() => document.body}>
           <span aria-hidden className='isr-tooltip-icon'>
             <SvgInfoCircular />
           </span>


### PR DESCRIPTION
Fix bug where tooltip on the info icon was being rendered in the wrong place when integrated into our Portal

Before:
![image](https://user-images.githubusercontent.com/11621478/150207718-a8a17546-64ba-46ef-85e2-be388a1c6e3e.png)

After:
![image](https://user-images.githubusercontent.com/11621478/150206584-f33c3d0a-233f-42db-8165-4a3baad4d210.png)
