### PR TITLE
Create stackblitzrc and update README

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,0 +1,5 @@
+{
+  "installDependencies": true,
+  "startCommand": "yarn start"
+}
+

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ This project was bootstrapped with [Vite](https://vitejs.dev/) and uses [Yarn v3
 
 The actual components are located in `src/components/` and are used by the test app located at `src/App.tsx`.
 
+You can open the test app in Stackblitz without cloning the repo:
+
+[![Open in Stackblitz](https://camo.githubusercontent.com/bf5c9492905b6d3b558552de2c848c7cce2e0a0f0ff922967115543de9441522/68747470733a2f2f646576656c6f7065722e737461636b626c69747a2e636f6d2f696d672f6f70656e5f696e5f737461636b626c69747a2e737667)](https://stackblitz.com/github/iTwin/synchronization-report-react)
+
 ### Available scripts
 
 #### `yarn start`


### PR DESCRIPTION
Stackblitz link will enable instantly previewing the test app in browser without cloning. The stackblitzrc file will run `yarn start` so that you don't need to run it manually.