### PR TITLE
Add Ability to Hide Blank Report Debug Ids

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Each line is a file pattern followed by one or more owners.
+# The owners will be requested for
+# review when someone opens a pull request.
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo, unless a later match takes precedence.
+*       @wsm95 @mayank99

--- a/src/components/ReportDebugIds.tsx
+++ b/src/components/ReportDebugIds.tsx
@@ -40,6 +40,7 @@ export type ReportDebugIdsProps = {
   className?: string;
   displayStrings?: Partial<typeof defaultDisplayStrings>;
   children?: React.ReactNode;
+  hideBlankValues?: boolean;
 };
 
 /**
@@ -48,9 +49,11 @@ export type ReportDebugIdsProps = {
  * `children` can be specified to add more content in the menu.
  */
 export const ReportDebugIds = (props: ReportDebugIdsProps) => {
+  const { data, hideBlankValues } = props;
+
   const context = React.useContext(ReportContext);
   const reportData = props.data?.reportData || context?.reportData.context;
-  const data = props.data;
+
   const displayStrings = React.useMemo(
     () => ({ ...defaultDisplayStrings, ...props.displayStrings }),
     [props.displayStrings]
@@ -75,50 +78,72 @@ export const ReportDebugIds = (props: ReportDebugIdsProps) => {
       <Tippy
         content={
           <div className='isr-support-debugIDWrapper'>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.activityid}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['Activity ID']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.briefcaseid}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['Briefcase ID']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.contextid}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['Context ID']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.contextName}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['Ctx. Name']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.jobDefID}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['Job Def. ID']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.jobid}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['Job ID']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.jobRunID}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['Job Run ID']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.modelid}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['iModel ID']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.modelName}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['iModel Name']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.organizationName}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['Org. Name']}</div>
-            </div>
-            <div className='isr-support-debugID'>
-              <div className='isr-support-debugID-title'>{`${displayStrings.userEmail}:`}</div>
-              <div className='isr-support-debugID-id'>{debugIDs['User Email']}</div>
-            </div>
+            {(!hideBlankValues || reportData?.activityid) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.activityid}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['Activity ID']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || reportData?.briefcaseid) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.briefcaseid}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['Briefcase ID']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || reportData?.contextid) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.contextid}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['Context ID']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || data?.contextName) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.contextName}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['Ctx. Name']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || data?.jobDefID) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.jobDefID}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['Job Def. ID']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || reportData?.jobid) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.jobid}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['Job ID']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || data?.jobRunID) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.jobRunID}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['Job Run ID']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || reportData?.imodelid) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.modelid}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['iModel ID']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || data?.modelName) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.modelName}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['iModel Name']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || data?.organizationName) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.organizationName}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['Org. Name']}</div>
+              </div>
+            )}
+            {(!hideBlankValues || data?.userEmail) && (
+              <div className='isr-support-debugID'>
+                <div className='isr-support-debugID-title'>{`${displayStrings.userEmail}:`}</div>
+                <div className='isr-support-debugID-id'>{debugIDs['User Email']}</div>
+              </div>
+            )}
             {props.children}
           </div>
         }

--- a/src/components/ReportDebugIds.tsx
+++ b/src/components/ReportDebugIds.tsx
@@ -10,14 +10,14 @@ import { ReportDataContext } from './report-data-typings';
 import Tippy from '@tippyjs/react';
 
 const defaultDisplayStrings = {
-  activityid: 'Activity ID',
-  briefcaseid: 'Briefcase ID',
-  contextid: 'Context ID',
+  activityid: 'Activity Id',
+  briefcaseid: 'Briefcase Id',
+  contextid: 'Context Id',
   contextName: 'Ctx. Name',
-  jobDefID: 'Job Def. ID',
-  jobid: 'Job ID',
-  jobRunID: 'Job Run ID',
-  modelid: 'Model ID',
+  jobDefID: 'Job Def. Id',
+  jobid: 'Job Id',
+  jobRunID: 'Job Run Id',
+  modelid: 'Model Id',
   modelName: 'Model Name',
   organizationName: 'Org. Name',
   userEmail: 'User Email',
@@ -40,7 +40,6 @@ export type ReportDebugIdsProps = {
   className?: string;
   displayStrings?: Partial<typeof defaultDisplayStrings>;
   children?: React.ReactNode;
-  hideBlankValues?: boolean;
 };
 
 /**
@@ -49,7 +48,7 @@ export type ReportDebugIdsProps = {
  * `children` can be specified to add more content in the menu.
  */
 export const ReportDebugIds = (props: ReportDebugIdsProps) => {
-  const { data, hideBlankValues } = props;
+  const { data } = props;
 
   const context = React.useContext(ReportContext);
   const reportData = props.data?.reportData || context?.reportData.context;
@@ -59,18 +58,18 @@ export const ReportDebugIds = (props: ReportDebugIdsProps) => {
     [props.displayStrings]
   );
 
-  const debugIDs = {
-    'Activity ID': reportData?.activityid ?? 'No Activity ID',
-    'Briefcase ID': reportData?.briefcaseid ?? 'No Briefcase ID',
-    'Context ID': reportData?.contextid ?? 'No Context ID',
-    'Ctx. Name': data?.contextName ?? 'No Context Name',
-    'Job Def. ID': data?.jobDefID ?? 'No Job Definition ID',
-    'Job ID': reportData?.jobid ?? 'No Job ID',
-    'Job Run ID': data?.jobRunID ?? 'No Job Run ID',
-    'iModel ID': reportData?.imodelid ?? 'No iModel ID',
-    'iModel Name': data?.modelName ?? 'No Model Name',
-    'Org. Name': data?.organizationName ?? 'No Organization Name',
-    'User Email': data?.userEmail ?? 'No User Email',
+  const debugIds = {
+    'Activity Id': reportData?.activityid === '' ? 'No Activity Id' : reportData?.activityid,
+    'Briefcase Id': reportData?.briefcaseid === '' ? 'No Briefcase Id' : reportData?.briefcaseid,
+    'Context Id': reportData?.contextid === '' ? 'No Context Id' : reportData?.contextid,
+    'Ctx. Name': data?.contextName === '' ? 'No Context Name' : data?.contextName,
+    'Job Def. Id': data?.jobDefID === '' ? 'No Job Definition Id' : data?.jobDefID,
+    'Job Id': reportData?.jobid === '' ? 'No Job Id' : reportData?.jobid,
+    'Job Run Id': data?.jobRunID === '' ? 'No Job Run Id' : data?.jobRunID,
+    'iModel Id': reportData?.imodelid === '' ? 'No iModel Id' : reportData?.imodelid,
+    'iModel Name': data?.modelName === '' ? 'No Model Name' : data?.modelName,
+    'Org. Name': data?.organizationName === '' ? 'No Organization Name' : data?.organizationName,
+    'User Email': data?.userEmail === '' ? 'No User Email' : data?.userEmail,
   };
 
   return (
@@ -78,70 +77,70 @@ export const ReportDebugIds = (props: ReportDebugIdsProps) => {
       <Tippy
         content={
           <div className='isr-support-debugIDWrapper'>
-            {(!hideBlankValues || reportData?.activityid) && (
+            {debugIds['Activity Id'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.activityid}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['Activity ID']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['Activity Id']}</div>
               </div>
             )}
-            {(!hideBlankValues || reportData?.briefcaseid) && (
+            {debugIds['Briefcase Id'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.briefcaseid}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['Briefcase ID']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['Briefcase Id']}</div>
               </div>
             )}
-            {(!hideBlankValues || reportData?.contextid) && (
+            {debugIds['Context Id'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.contextid}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['Context ID']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['Context Id']}</div>
               </div>
             )}
-            {(!hideBlankValues || data?.contextName) && (
+            {debugIds['Ctx. Name'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.contextName}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['Ctx. Name']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['Ctx. Name']}</div>
               </div>
             )}
-            {(!hideBlankValues || data?.jobDefID) && (
+            {debugIds['Job Def. Id'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.jobDefID}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['Job Def. ID']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['Job Def. Id']}</div>
               </div>
             )}
-            {(!hideBlankValues || reportData?.jobid) && (
+            {debugIds['Job Id'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.jobid}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['Job ID']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['Job Id']}</div>
               </div>
             )}
-            {(!hideBlankValues || data?.jobRunID) && (
+            {debugIds['Job Run Id'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.jobRunID}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['Job Run ID']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['Job Run Id']}</div>
               </div>
             )}
-            {(!hideBlankValues || reportData?.imodelid) && (
+            {debugIds['iModel Id'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.modelid}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['iModel ID']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['iModel Id']}</div>
               </div>
             )}
-            {(!hideBlankValues || data?.modelName) && (
+            {debugIds['iModel Name'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.modelName}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['iModel Name']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['iModel Name']}</div>
               </div>
             )}
-            {(!hideBlankValues || data?.organizationName) && (
+            {debugIds['Org. Name'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.organizationName}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['Org. Name']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['Org. Name']}</div>
               </div>
             )}
-            {(!hideBlankValues || data?.userEmail) && (
+            {debugIds['User Email'] && (
               <div className='isr-support-debugID'>
                 <div className='isr-support-debugID-title'>{`${displayStrings.userEmail}:`}</div>
-                <div className='isr-support-debugID-id'>{debugIDs['User Email']}</div>
+                <div className='isr-support-debugID-id'>{debugIds['User Email']}</div>
               </div>
             )}
             {props.children}


### PR DESCRIPTION
Add a prop to the `ReportDebugIds` component allowing the consumer to hide any blank/unset values. 

Some values we can pass into the `ReportDebugIds` are tedious or inefficient to set (eg. the Org Name and User Email values inside of the InstantOn portal). We do not want to confuse users say that there is "No Value" for this, so we are suggesting we just hide these values from the user.