### PR TITLE
Fix 'file(s) processed' Count on ReportBanner

### DIFF
--- a/src/components/ReportBanner.tsx
+++ b/src/components/ReportBanner.tsx
@@ -43,9 +43,15 @@ export const ReportBanner = (props: ReportBannerProps) => {
     return props.fileRecords || context?.reportData.filerecords || [];
   }, [context?.reportData.filerecords, props.fileRecords]);
 
-  const filesProcessed = React.useMemo(() => {
-    return props.filesProcessed || context?.reportData.sourceFilesInfo?.Files || [];
-  }, [context?.reportData.sourceFilesInfo?.Files, props.filesProcessed]);
+  const filesProcessed: SourceFile[] = React.useMemo(() => {
+    if (props.filesProcessed) {
+      return [...filesProcessed];
+    } else if (context?.reportData.sourceFilesInfo?.Files) {
+      return [context.reportData.sourceFilesInfo, ...context.reportData.sourceFilesInfo.Files];
+    }
+
+    return [];
+  }, [context?.reportData.sourceFilesInfo, props.filesProcessed]);
 
   const currentTab = React.useMemo(() => {
     return props.currentTab || context?.currentTab;

--- a/src/test-report.ts
+++ b/src/test-report.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { AuditInfo, ReportData, SourceFile } from './components/typings';
+
+import { AuditInfo, ReportData, SourceFile } from './components/report-data-typings';
 
 export default {
   context: {


### PR DESCRIPTION
The current count on the `ReportBanner` component does not include the main file.

Before:
![image](https://user-images.githubusercontent.com/11621478/155357397-a9ea82c1-9bad-456a-b0b9-65b4ae34b55e.png)

After:
![image](https://user-images.githubusercontent.com/11621478/155357186-aa7001d6-5f2c-4c3c-adbd-337ce35db209.png)
