### PR TITLE
Add 'Processed with issues' status to FilesTable

### DIFF
--- a/src/components/FilesTable.tsx
+++ b/src/components/FilesTable.tsx
@@ -18,7 +18,7 @@ import { AuditRecord } from '.';
 const defaultDisplayStrings = {
   failed: 'Failed',
   processed: 'Processed',
-  processedWithIssues: 'Processed with Issues',
+  processedWithIssues: 'Processed with issues',
   fileName: 'File name',
   status: 'Status',
   path: 'Path',
@@ -109,14 +109,6 @@ export const FilesTable = ({
     return fileStatusMap;
   }, [context?.reportData.filerecords, data, fileRecords]);
 
-  type TableRow = Partial<typeof data[number]>;
-  const sortByStatus = React.useCallback((rowA: Row<TableRow>, rowB: Row<TableRow>) => {
-    const levelsOrder = ['Proccessed', 'Failed'];
-    const indexA = levelsOrder.indexOf(rowA.original.state || '');
-    const indexB = levelsOrder.indexOf(rowB.original.state || '');
-    return indexA > indexB ? 1 : -1;
-  }, []);
-
   const columns = React.useMemo(
     () => [
       {
@@ -144,11 +136,9 @@ export const FilesTable = ({
           },
           {
             id: 'status',
-            accessor: 'status',
             Header: displayStrings['status'],
             minWidth: 75,
             maxWidth: 180,
-            sortType: sortByStatus,
             Cell: (props: CellProps<SourceFile>) => {
               /* Note: This field can be changed to `State` value from row props. */
               return !props.row.original.fileExists && !props.row.original.bimFileExists ? (

--- a/src/test-report.ts
+++ b/src/test-report.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { AuditInfo, ReportData, SourceFile } from './components/typings';
+import { AuditInfo, ReportData, SourceFile } from './components/report-data-typings';
 
 export default {
   context: {


### PR DESCRIPTION
Added a new value for the status column on the FilesTable, 'Processed with issues'. This comes from a conversion with UX regarded files that are processed but still have issues inside the DetailsTable.

![image](https://user-images.githubusercontent.com/11621478/156053025-6f51ee09-18ef-4e70-81f5-015b10c8bf0a.png)
