### PR TITLE
Fix 'file(s) failed to synchronize' count

### DIFF
--- a/src/components/ReportBanner.tsx
+++ b/src/components/ReportBanner.tsx
@@ -86,8 +86,11 @@ export const ReportBanner = (props: ReportBannerProps) => {
   React.useEffect(() => {
     let failed = 0;
     filesProcessed?.forEach((file) => {
-      if (file.state === 'Failed' || file.state === 'Missing') failed++;
+      if (file.state === 'Failed' || file.state === 'Missing' || !file.bimFileExists || !file.fileExists) {
+        failed++;
+      }
     });
+
     setFailedFileCount(failed);
   }, [filesProcessed]);
 

--- a/src/components/ReportBanner.tsx
+++ b/src/components/ReportBanner.tsx
@@ -129,12 +129,14 @@ export const ReportBanner = (props: ReportBannerProps) => {
                   </span>
                 </span>
               ) : (
-                <span className='isr-header-banner-section'>
-                  <StatusIcon status='success' />
-                  <span className='isr-header-banner-section-message'>
-                    {displayStrings.noSynchronizationIssuesFound}
+                filesProcessed.length !== failedFileCount && (
+                  <span className='isr-header-banner-section'>
+                    <StatusIcon status='success' />
+                    <span className='isr-header-banner-section-message'>
+                      {displayStrings.noSynchronizationIssuesFound}
+                    </span>
                   </span>
-                </span>
+                )
               )}
             </div>
           )}


### PR DESCRIPTION
Current `failedFileCount` does not include files that are missing where the `state` property is empty

Before
![image](https://user-images.githubusercontent.com/11621478/156624543-87ac5e4e-29d3-4128-a705-49ddcb861f9f.png)

After
![image](https://user-images.githubusercontent.com/11621478/156624478-074a52f2-8460-4f73-9c32-67919aaacc5e.png)


Quick note: This does introduce some confusion to the UX IMO. We have a file that is missing and in the 'failed' state, but at the same time we are displaying a message that is saying 'No synchronization issues found'. Maybe we should add some logic where if the file count and failed file count are equal we do not display the 'No synchronization issues found' message.