### PR TITLE
 Fix 'file(s) failed to synchronize' count (again)

### DIFF
--- a/src/components/ReportBanner.tsx
+++ b/src/components/ReportBanner.tsx
@@ -86,7 +86,7 @@ export const ReportBanner = (props: ReportBannerProps) => {
   React.useEffect(() => {
     let failed = 0;
     filesProcessed?.forEach((file) => {
-      if (file.state === 'Failed' || file.state === 'Missing' || (!file.bimFileExists && !file.fileExists)) {
+      if (!file.bimFileExists && !file.fileExists) {
         failed++;
       }
     });

--- a/src/components/ReportBanner.tsx
+++ b/src/components/ReportBanner.tsx
@@ -86,7 +86,7 @@ export const ReportBanner = (props: ReportBannerProps) => {
   React.useEffect(() => {
     let failed = 0;
     filesProcessed?.forEach((file) => {
-      if (file.state === 'Failed' || file.state === 'Missing' || !file.bimFileExists || !file.fileExists) {
+      if (file.state === 'Failed' || file.state === 'Missing' || (!file.bimFileExists && !file.fileExists)) {
         failed++;
       }
     });


### PR DESCRIPTION
I have changed the way we calculate the count of failed files inside of the `ReportBanner` to match the logic inside the `FilesTable` for how we determine if a file is `Failed` or not.