### PR TITLE
Externalize dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/synchronization-report-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "files": [
     "dist"
   ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,9 @@ export default defineConfig({
         '@itwin/itwinui-css',
         '@itwin/itwinui-variables',
         'react-table',
+        'classnames',
+        'tippy.js',
+        '@tippyjs/react'
       ],
       output: {
         globals: { react: 'React' },

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,7 +18,14 @@ export default defineConfig({
       fileName: () => 'index.js',
     },
     rollupOptions: {
-      external: ['react', '@itwin/itwinui-react', '@itwin/itwinui-css'],
+      external: [
+        'react',
+        'react-dom',
+        '@itwin/itwinui-react',
+        '@itwin/itwinui-css',
+        '@itwin/itwinui-variables',
+        'react-table',
+      ],
       output: {
         globals: { react: 'React' },
       },


### PR DESCRIPTION
Populated the `external` list with some missing deps, biggest one was `react-dom`. Some more might have still been missed. The build system could probably be improved to handle this automatically. In hindsight, vite was not a good option for publishing a library. But this will do for now.

This reduced the bundle size by like 1000%.

| Before (173KB) | After (17KB) |
| --- | --- |
| ![](https://user-images.githubusercontent.com/9084735/210611816-3aacb93c-cf85-431e-a742-5ff2e29b6c30.png) | ![](https://user-images.githubusercontent.com/9084735/210612928-3fb89cea-291e-4b4e-8f23-41c7ce2d4706.png) |