### PR TITLE
add wildcard `exports` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@itwin/synchronization-report-react",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "files": [
     "dist"
   ],
   "module": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./style.css": "./dist/style.css"
+    "./style.css": "./dist/style.css",
+    "./*": "./*"
   },
   "typings": "./dist/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
this allows users to import from all paths, such as:
```
import '@itwin/synchronization-report-react/dist/style.css';
```
```
import type * as ReportDataTypings from '@itwin/synchronization-report-react/dist/report-data-typings';
```

i did this because i encountered an error in a webpack app when importing from `dist/style.css`