### PR TITLE
UI changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/synchronization-report-react",
-  "version": "2.1.0-dev.1",
+  "version": "2.1.0-dev.2",
   "files": [
     "dist"
   ],

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -323,7 +323,7 @@ export const ProblemsTable = ({
       className={classnames('isr-problems-table', className)}
       columns={columns}
       data={data}
-      emptyTableContent='No data.'
+      emptyTableContent={`No ${context?.focusedIssue} Data`}
       emptyFilteredTableContent='No results found. Clear or try another filter.'
       isSortable
       initialState={{ sortBy: [{ id: 'level' }] }}

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -156,7 +156,7 @@ export const ProblemsTable = ({
     const levelsOrder = ['Fatal', 'Error', 'Critical', 'Warning', 'Info'];
     const indexA = levelsOrder.indexOf(rowA.original.level || '');
     const indexB = levelsOrder.indexOf(rowB.original.level || '');
-    return indexA > indexB ? -1 : 1;
+    return indexA > indexB ? 1 : -1;
   }, []);
 
   const columns = React.useMemo(

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -102,7 +102,6 @@ export const ProblemsTable = ({
 
   const data = React.useMemo(() => {
     const files = fileRecords || context?.reportData.filerecords || [];
-    console.log({ files });
     const reports = files
       .flatMap(({ file, auditrecords }) =>
         (auditrecords ?? []).flatMap(({ auditinfo }) => {

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -129,17 +129,11 @@ export const ProblemsTable = ({
         let bannerLevel: Issues = 'Info';
         if (level === 'Error' || level === 'Fatal') bannerLevel = 'Error';
         else if (level === 'Warning' || level === 'Critical') bannerLevel = 'Warning';
-        return context?.focusedIssues.some((issue) => bannerLevel === issue);
+        return context?.focusedIssue === bannerLevel || context?.focusedIssue === 'All';
       });
 
     return expandReports(reports);
-  }, [
-    fileRecords,
-    context?.reportData.filerecords,
-    context?.focusedWorkflows,
-    context?.focusedIssues,
-    workflowMapping,
-  ]);
+  }, [fileRecords, context?.reportData.filerecords, context?.focusedWorkflows, context?.focusedIssue, workflowMapping]);
 
   const displayStrings = React.useMemo(
     () => ({ ...defaultDisplayStrings, ...userDisplayStrings }),

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -301,12 +301,16 @@ export const ProblemsTable = ({
   const onRowClick = React.useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (event: React.MouseEvent<Element, MouseEvent>, row: Row<Record<string, any>>): void => {
-      context?.setCurrentAuditInfo({
-        ...row.original,
-        fileName: row.original.fileName ?? getFileNameFromId(row.original.fileId),
-      });
+      if (row.subRows.length) {
+        row.toggleRowExpanded();
+      } else {
+        context?.setCurrentAuditInfo({
+          ...row.original,
+          fileName: row.original.fileName ?? getFileNameFromId(row.original.fileId),
+        });
 
-      context?.setActiveRow(row.id);
+        context?.setActiveRow(row.id);
+      }
     },
     [context, getFileNameFromId]
   );

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -30,7 +30,7 @@ const defaultDisplayStrings = {
   Warning: 'Warning',
   Info: 'Info',
   fileName: 'File name',
-  level: 'Status',
+  level: 'Severity',
   category: 'Issue',
   type: 'Type',
   message: 'Message',

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -31,7 +31,7 @@ const defaultDisplayStrings = {
   Info: 'Info',
   fileName: 'File name',
   level: 'Severity',
-  category: 'Issue',
+  category: 'Category',
   type: 'Type',
   message: 'Message',
 };

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -92,7 +92,7 @@ export const ProblemsTable = ({
     const processedReports = [];
     for (const category of Object.keys(expandableReports)) {
       processedReports.push({
-        category,
+        category: `${category} (${expandableReports[category].length})`,
         subRows: expandableReports[category],
       });
     }

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -102,6 +102,7 @@ export const ProblemsTable = ({
 
   const data = React.useMemo(() => {
     const files = fileRecords || context?.reportData.filerecords || [];
+    console.log({ files });
     const reports = files
       .flatMap(({ file, auditrecords }) =>
         (auditrecords ?? []).flatMap(({ auditinfo }) => {
@@ -156,7 +157,7 @@ export const ProblemsTable = ({
     const levelsOrder = ['Fatal', 'Error', 'Critical', 'Warning', 'Info'];
     const indexA = levelsOrder.indexOf(rowA.original.level || '');
     const indexB = levelsOrder.indexOf(rowB.original.level || '');
-    return indexA > indexB ? 1 : -1;
+    return indexA > indexB ? -1 : 1;
   }, []);
 
   const columns = React.useMemo(

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -223,7 +223,7 @@ export const ProblemsTable = ({
                   ) : undefined
                 }
               >
-                {level && level in displayStrings ? displayStrings.level : level}
+                {level}
               </DefaultCell>
             );
           },

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -180,7 +180,7 @@ export const ProblemsTable = ({
           Header: displayStrings.type,
           Filter: tableFilters.TextFilter(),
           minWidth: 50,
-          maxWidth: 250,
+          maxWidth: 170,
           Cell: (row: CellProps<Report>) => {
             return (
               <Anchor
@@ -201,8 +201,8 @@ export const ProblemsTable = ({
           accessor: 'level',
           Header: displayStrings.level,
           Filter: tableFilters.TextFilter(),
-          minWidth: 75,
-          maxWidth: 250,
+          minWidth: 50,
+          maxWidth: 170,
           sortType: sortByLevel,
           cellRenderer: ({ cellElementProps, cellProps }: CellRendererProps<Report>) => {
             const level = cellProps.row.original.level;

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -133,11 +133,11 @@ export const Report = ({
                 <ReportDebugIds />
               </ReportTitleWrapper>
               <ReportTimestamp />
+              <Label as='span'>Issues found by severity</Label>
               <ReportHeaderBannerWrapper>
                 <ReportBanner />
               </ReportHeaderBannerWrapper>
               <ReportTableSelectWrapper>
-                <Label as='span'>Synchronization Issues</Label>
                 <ReportTableSelect />
               </ReportTableSelectWrapper>
               <ReportInfoPanelWrapper>

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -133,8 +133,8 @@ export const Report = ({
                 <ReportDebugIds />
               </ReportTitleWrapper>
               <ReportTimestamp />
-              <Label as='span'>Issues found by severity</Label>
               <ReportHeaderBannerWrapper>
+                <Label as='span'>Issues found by severity</Label>
                 <ReportBanner />
               </ReportHeaderBannerWrapper>
               <ReportTableSelectWrapper>

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -23,7 +23,7 @@ import { ReportTitleWrapper } from './ReportTitleWrapper';
 import { defaultWorkflowMapping } from './report-workflow-mapping';
 
 type Levels = 'Error' | 'Warning' | 'Info' | 'Fatal' | 'Critical';
-export type Issues = 'Error' | 'Warning' | 'Info';
+export type Issues = 'Error' | 'Warning' | 'Info' | 'All';
 export type Tables = 'files' | 'problems';
 
 type AuditInfo = Partial<{
@@ -43,8 +43,8 @@ export const ReportContext = React.createContext<
       setCurrentTable: (table: Tables | ((prev: Tables) => Tables)) => void;
       currentAuditInfo?: AuditInfo;
       setCurrentAuditInfo: (auditInfo?: AuditInfo) => void;
-      focusedIssues: Issues[];
-      setFocusedIssues: (issues: Issues[] | ((issues: Issues[]) => Issues[])) => void;
+      focusedIssue: Issues;
+      setFocusedIssue: (issue: Issues) => void;
       focusedWorkflows: string[];
       setFocusedWorkflows: (issues: string[] | ((issues: string[]) => string[])) => void;
       activeRow: string;
@@ -95,7 +95,7 @@ export const Report = ({
 }) => {
   const [selectedTable, setSelectedTable] = React.useState<Tables>('problems');
   const [currentAuditInfo, setCurrentAuditInfo] = React.useState<AuditInfo | undefined>();
-  const [focusedIssues, setFocusedIssues] = React.useState<Issues[]>(['Error', 'Warning', 'Info']);
+  const [focusedIssue, setFocusedIssue] = React.useState<Issues>('All');
   const [focusedWorkflows, setFocusedWorkflows] = React.useState<string[]>([]);
   const [activeRow, setActiveRow] = React.useState<string>('');
 
@@ -117,8 +117,8 @@ export const Report = ({
           setCurrentTable: setSelectedTable,
           currentAuditInfo,
           setCurrentAuditInfo,
-          focusedIssues: focusedIssues,
-          setFocusedIssues: setFocusedIssues,
+          focusedIssue: focusedIssue,
+          setFocusedIssue: setFocusedIssue,
           focusedWorkflows: focusedWorkflows,
           setFocusedWorkflows: setFocusedWorkflows,
           activeRow: activeRow,

--- a/src/components/ReportBanner.tsx
+++ b/src/components/ReportBanner.tsx
@@ -84,7 +84,7 @@ export const ReportBanner = (props: ReportBannerProps) => {
           record.auditinfo.type &&
           Object.hasOwn(context.workflowMapping, record.auditinfo.category) &&
           Object.hasOwn(context.workflowMapping[record.auditinfo.category], record.auditinfo.type) &&
-          context?.focusedIssues.some((issue) => bannerLevel === issue)
+          context?.focusedIssue === bannerLevel
         ) {
           const workflows = context.workflowMapping[record.auditinfo.category][record.auditinfo.type];
           workflows.forEach((w) => {
@@ -119,22 +119,14 @@ export const ReportBanner = (props: ReportBannerProps) => {
     setWarningCount(warning);
     setInfoCount(info);
     setIssuesCount(error + warning + info);
-  }, [context?.focusedIssues, context?.focusedWorkflows, context?.workflowMapping, fileRecords]);
+  }, [context?.focusedIssue, context?.focusedWorkflows, context?.workflowMapping, fileRecords]);
 
-  const onClickIssue = React.useCallback(
-    (issue: Issues) =>
-      context?.setFocusedIssues((focusedIssues) =>
-        focusedIssues.some((currentIssue) => issue === currentIssue)
-          ? focusedIssues.filter((i) => i !== issue)
-          : [...focusedIssues, issue]
-      ),
-    [context]
-  );
+  const onClickIssue = React.useCallback((issue: Issues) => context?.setFocusedIssue(issue), [context]);
 
   return (
     <Surface elevation={1} className='isr-banner-container'>
       <>
-        <BannerTile icon={<SvgFlag />}>
+        <BannerTile icon={<SvgFlag />} onClick={() => onClickIssue('All')} selected={context?.focusedIssue === 'All'}>
           <Text variant='title' style={{ fontWeight: 'bold' }}>
             {issuesCount}
           </Text>
@@ -142,7 +134,7 @@ export const ReportBanner = (props: ReportBannerProps) => {
         </BannerTile>
         <BannerTile
           onClick={() => onClickIssue('Error')}
-          selected={context?.focusedIssues.some((p) => p === 'Error')}
+          selected={context?.focusedIssue === 'Error'}
           icon={<StatusIcon status='error' />}
         >
           <Text variant='title' style={{ fontWeight: 'bold' }}>
@@ -152,7 +144,7 @@ export const ReportBanner = (props: ReportBannerProps) => {
         </BannerTile>
         <BannerTile
           onClick={() => onClickIssue('Warning')}
-          selected={context?.focusedIssues.some((p) => p === 'Warning')}
+          selected={context?.focusedIssue === 'Warning'}
           icon={<StatusIcon status='warning' />}
         >
           <Text variant='title' style={{ fontWeight: 'bold' }}>
@@ -162,7 +154,7 @@ export const ReportBanner = (props: ReportBannerProps) => {
         </BannerTile>
         <BannerTile
           onClick={() => onClickIssue('Info')}
-          selected={context?.focusedIssues.some((p) => p === 'Info')}
+          selected={context?.focusedIssue === 'Info'}
           icon={<StatusIcon status='informational' />}
         >
           <Text variant='title' style={{ fontWeight: 'bold' }}>

--- a/src/components/ReportBanner.tsx
+++ b/src/components/ReportBanner.tsx
@@ -134,6 +134,12 @@ export const ReportBanner = (props: ReportBannerProps) => {
   return (
     <Surface elevation={1} className='isr-banner-container'>
       <>
+        <BannerTile icon={<SvgFlag />}>
+          <Text variant='title' style={{ fontWeight: 'bold' }}>
+            {issuesCount}
+          </Text>
+          <Text variant='small'>{displayStrings.totalIssues}</Text>
+        </BannerTile>
         <BannerTile
           onClick={() => onClickIssue('Error')}
           selected={context?.focusedIssues.some((p) => p === 'Error')}
@@ -163,12 +169,6 @@ export const ReportBanner = (props: ReportBannerProps) => {
             {infoCount}
           </Text>
           <Text variant='small'>{displayStrings.otherIssues}</Text>
-        </BannerTile>
-        <BannerTile icon={<SvgFlag />}>
-          <Text variant='title' style={{ fontWeight: 'bold' }}>
-            {issuesCount}
-          </Text>
-          <Text variant='small'>{displayStrings.totalIssues}</Text>
         </BannerTile>
       </>
     </Surface>

--- a/src/components/ReportBanner.tsx
+++ b/src/components/ReportBanner.tsx
@@ -13,7 +13,7 @@ import SvgFlag from '@itwin/itwinui-icons-react/esm/icons/Flag';
 const defaultDisplayStrings = {
   errors: 'Errors',
   warnings: 'Warnings',
-  otherIssues: 'Other issues',
+  otherIssues: 'Info',
   totalIssues: 'Total Issues',
   unorganized: 'Unorganized',
 };

--- a/src/components/ReportHeaderBannerWrapper.scss
+++ b/src/components/ReportHeaderBannerWrapper.scss
@@ -5,7 +5,8 @@
 
 .isr-report-header-banner {
   display: flex;
-  gap: var(--iui-size-l);
+  flex-direction: column;
+  gap: var(--iui-size-xs);
   overflow-x: auto;
   padding: var(--iui-size-s) var(--iui-size-xs);
 }

--- a/src/components/ReportTableSelect.tsx
+++ b/src/components/ReportTableSelect.tsx
@@ -8,7 +8,7 @@ import { ReportContext, Tables } from './Report';
 
 const defaultDisplayStrings = {
   files: 'Files',
-  problems: 'Problems',
+  problems: 'Issues',
 };
 
 /**

--- a/src/components/ReportTableSelectWrapper.scss
+++ b/src/components/ReportTableSelectWrapper.scss
@@ -5,7 +5,8 @@
 
 .isr-table-select-wrapper {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  flex-direction: column;
   justify-content: space-between;
   gap: var(--iui-size-xs);
 }

--- a/src/components/ReportTableSelectWrapper.scss
+++ b/src/components/ReportTableSelectWrapper.scss
@@ -5,8 +5,4 @@
 
 .isr-table-select-wrapper {
   display: flex;
-  align-items: flex-start;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: var(--iui-size-xs);
 }

--- a/src/components/ReportTimestamp.scss
+++ b/src/components/ReportTimestamp.scss
@@ -7,4 +7,8 @@
   display: flex;
   padding: var(--iui-size-s) 0;
   width: fit-content;
+
+  svg {
+    vertical-align: text-bottom;
+  }
 }

--- a/src/components/ReportTimestamp.tsx
+++ b/src/components/ReportTimestamp.tsx
@@ -77,7 +77,7 @@ export const ReportTimestamp = ({
       <span>
         <Text>
           {' '}
-          <SvgClock /> {date} {time} {displayStrings.syncTime} | <SvgDocument /> {allFilesProcessed.length}{' '}
+          <SvgClock /> {date} {time} {displayStrings.syncTime} | <SvgDocument /> {filesCount}/{allFilesProcessed.length}{' '}
           {displayStrings.files}
         </Text>
       </span>

--- a/src/components/ReportTimestamp.tsx
+++ b/src/components/ReportTimestamp.tsx
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { ReportContext } from './Report';
-import { Surface, Text } from '@itwin/itwinui-react';
-import { BannerTile } from './utils';
+import { Text } from '@itwin/itwinui-react';
 import SvgClock from '@itwin/itwinui-icons-react/cjs/icons/Clock';
 import './ReportTimestamp.scss';
 import SvgDocument from '@itwin/itwinui-icons-react/cjs/icons/Document';


### PR DESCRIPTION
- Make ‘all’ tile clickable and make it so only one tile can be selected at a time. Default is
all
- All should be first [All, Errors, Warnings, Info]
- Clicking on Group row will not bring up RHS panel. Should expand/collapse row
- Group row should have count of grouped rows and grouped value
- Status Column should become Severity
- Issue column should become Category
- Other Issues should become ‘Info’
- In status columnDefault sort on Severity column should be Errors, Warnings Info
- Shrink Status column to fit so we can make message and file longer
-nShow by drop down on the left, not right. It should toggle between different grouping
modes
- Change ‘Synchronization issues’ text to ‘Issues found by severity’ and move to above
tiles that let you select by severity
<img width="904" alt="Screen Shot 2023-05-27 at 11 32 51 AM" src="https://github.com/iTwin/synchronization-report-react/assets/100853841/423cb202-2eb4-4a3a-bc6a-946b837fbd29">
