### PR TITLE
Remove dev versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/synchronization-report-react",
-  "version": "2.1.0-dev.4.1.5",
+  "version": "2.1.1",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Move to a more standard semantic versioning. This will hopefully fix a problem parsing this package as a dependency in older npm versions.