### PR TITLE
Fix Dwg_0203 issue article url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/synchronization-report-react",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "files": [
     "dist"
   ],

--- a/src/components/help-articles.ts
+++ b/src/components/help-articles.ts
@@ -13,7 +13,7 @@ const helpArticles: { [issueId: string]: string } = {
   Dgn_0205: `${SyncWikiBaseUrl}/68077/itwin-extents#OutlierElements`,
   Dgn_0214: `${SyncWikiBaseUrl}/68291/missing-data#Dgn_0214`,
   // "Dgn_0215": ``,
-  Dwg_0203: `"${SyncWikiBaseUrl}/68522/data-access#Dwg_0203`,
+  Dwg_0203: `${SyncWikiBaseUrl}/68522/data-access#Dwg_0203`,
   Dwg_0199: `${SyncWikiBaseUrl}/68521/unexpected-data#Dwg_0199`,
   Revit_0002: `${SyncWikiBaseUrl}/68291/missing-data#Revit0002`,
   Revit_0025: `${SyncWikiBaseUrl}/68291/missing-data#Revit0025`,


### PR DESCRIPTION
Removed extra quote at beginning of url that was causing the url to be interpreted as a relative rather than absolute.
Bump patch version