### PR TITLE
Fixed Flickyness during logging in AppInsight.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/synchronization-report-react",
-  "version": "2.1.12",
+  "version": "2.1.13-dev.0",
   "files": [
     "dist"
   ],

--- a/src/components/ApplicationInsightCustomEvent.tsx
+++ b/src/components/ApplicationInsightCustomEvent.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { ApplicationInsightService } from './ApplicationInsightService';
 import { TotalIssueCount } from './Report';
-import { syncReportOpenTelemetryDataType } from './report-data-typings';
+import { issueArticleOpenTelemetryDataType, syncReportOpenTelemetryDataType } from './report-data-typings';
 
 export function runSyncReportOpenEvent(
   applicationInsight?: ApplicationInsightService,
@@ -31,15 +31,14 @@ export function runSyncReportOpenEvent(
 export function runIssueArticleOpenEvent(
   applicationInsight?: ApplicationInsightService,
   clickedIssueId?: string,
-  issueArticlePropsData?: any,
-  onIssueArticleOpenEventPerform?: () => void
+  issueArticlePropsData?: issueArticleOpenTelemetryDataType,
+  onIssueArticleOpenEventPerform?: (issueId: string) => void
 ) {
   const issueArticleEventData = { issueId: clickedIssueId };
   const completeTelemtry = { ...issueArticlePropsData, ...issueArticleEventData };
 
   if (applicationInsight) {
     applicationInsight.trackCustomEvent('IssueArticleOpenedEvent', completeTelemtry);
-    applicationInsight.flushEvent();
   }
-  onIssueArticleOpenEventPerform?.();
+  onIssueArticleOpenEventPerform?.(clickedIssueId ? clickedIssueId : '');
 }

--- a/src/components/ApplicationInsightService.tsx
+++ b/src/components/ApplicationInsightService.tsx
@@ -13,6 +13,8 @@ export class ApplicationInsightService {
       config: {
         connectionString: connectionString,
         extensions: [reactPlugin],
+        maxBatchInterval: 0,
+        isStorageUseDisabled: true,
       },
     });
     this.appInsight.loadAppInsights();

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -140,6 +140,12 @@ export const Report = ({
   });
 
   useEffect(() => {
+    return () => {
+      onSyncReportClose();
+    };
+  }, [data]);
+
+  useEffect(() => {
     if (applicationInsightConnectionString) {
       applicationInsight.current = new ApplicationInsightService(applicationInsightConnectionString);
     }

--- a/src/components/report-data-typings.ts
+++ b/src/components/report-data-typings.ts
@@ -93,7 +93,7 @@ export interface SyncReportOpenedEventDataType {
 
 export interface IssueArticleOpenEventDataType {
   issueArticleOpenTelemetry?: issueArticleOpenTelemetryDataType;
-  onIssueArticleOpenEventPerform?: () => void;
+  onIssueArticleOpenEventPerform?: (issueId: string) => void;
 }
 
 export interface syncReportOpenTelemetryDataType {
@@ -118,4 +118,3 @@ export interface issueArticleOpenTelemetryDataType {
   isDetailsColumnEnabled?: string;
   ultimateId?: string;
 }
-// e


### PR DESCRIPTION
We were facing some flickyness during logging the telemetry in Application Insights . The flickyness was happening for "SyncReportOpenedEvent" which was triggering during closing the report page. In this PR that issue is fixed .