### PR TITLE
Changed package version for adding AppInsight.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/synchronization-report-react",
-  "version": "2.1.13-dev.0",
+  "version": "2.1.14",
   "files": [
     "dist"
   ],

--- a/src/components/report-data-typings.ts
+++ b/src/components/report-data-typings.ts
@@ -105,6 +105,7 @@ export interface syncReportOpenTelemetryDataType {
   connectionId?: string;
   runId?: string;
   reportId?: string;
+  isDetailsColumnEnabled?: string;
   ultimateId?: string;
 }
 


### PR DESCRIPTION
From this version we are providing support for tracking custom events using Application Insight , and we have two inbuilt custom event - 

1. **SyncReportOpenedEvent** : It fires when we closes the report and it gathers information regarding the behavior of users during using our report whether they are clicking the issue article links or not, we can track that.

2. **IssueArticleOpenedEvent** : It fires when user opens the report and clicks on the issue article links.

Consuming application needs to pass Application Insight Connection String , then our inbuilt telemetry (eg. count of IssueIds , count of IssueId Links and count of Issue Id links clicked etc) will be shown in the App Insight under the above custom event. If any other telemetry is passed in the proper form then that will be automatically added with our own telemetry.