### PR TITLE
Added support for Instrumentation Key in App Insight Initialization.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/synchronization-report-react",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "files": [
     "dist"
   ],

--- a/src/components/ApplicationInsightService.tsx
+++ b/src/components/ApplicationInsightService.tsx
@@ -7,11 +7,12 @@ import { ReactPlugin } from '@microsoft/applicationinsights-react-js';
 
 export class ApplicationInsightService {
   private appInsight: ApplicationInsights;
-  constructor(connectionString: string) {
+  constructor(connectionString?: string, instrumentationKey?: string) {
     const reactPlugin = new ReactPlugin();
     this.appInsight = new ApplicationInsights({
       config: {
         connectionString: connectionString,
+        instrumentationKey: instrumentationKey,
         extensions: [reactPlugin],
         maxBatchInterval: 0,
         isStorageUseDisabled: true,

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -102,12 +102,14 @@ export const Report = ({
   children,
   className,
   applicationInsightConnectionString,
+  applicationInsightInstrumentationKey,
   SyncReportOpenedEventProps,
   issueArticleOpenEventProps,
 }: {
   /** The report data should be compatible with the type definitions. */
   data: ReportData;
   applicationInsightConnectionString?: string;
+  applicationInsightInstrumentationKey?: string;
   SyncReportOpenedEventProps?: SyncReportOpenedEventDataType;
   issueArticleOpenEventProps?: IssueArticleOpenEventDataType;
   workflowMapping?: WorkflowMapping;
@@ -146,8 +148,11 @@ export const Report = ({
   }, [data]);
 
   useEffect(() => {
-    if (applicationInsightConnectionString) {
-      applicationInsight.current = new ApplicationInsightService(applicationInsightConnectionString);
+    if (applicationInsightConnectionString || applicationInsightInstrumentationKey) {
+      applicationInsight.current = new ApplicationInsightService(
+        applicationInsightConnectionString,
+        applicationInsightInstrumentationKey
+      );
     }
   }, []);
 
@@ -175,7 +180,11 @@ export const Report = ({
   }, [data]);
 
   const onSyncReportClose = useCallback(() => {
-    if (data != null && shouldRunAIEvent.current && applicationInsightConnectionString) {
+    if (
+      data != null &&
+      shouldRunAIEvent.current &&
+      (applicationInsightConnectionString || applicationInsightInstrumentationKey)
+    ) {
       shouldRunAIEvent.current = false;
       runSyncReportOpenEvent(
         applicationInsight.current,

--- a/src/components/report-data-typings.ts
+++ b/src/components/report-data-typings.ts
@@ -106,6 +106,7 @@ export interface syncReportOpenTelemetryDataType {
   runId?: string;
   reportId?: string;
   isDetailsColumnEnabled?: string;
+  consumedApplicationName?: string;
   ultimateId?: string;
 }
 
@@ -117,5 +118,6 @@ export interface issueArticleOpenTelemetryDataType {
   runId?: string;
   reportId?: string;
   isDetailsColumnEnabled?: string;
+  consumedApplicationName?: string;
   ultimateId?: string;
 }


### PR DESCRIPTION
From now we can pass instrumentation key as a prop to configure and initialize application insight. User can pass connection String or Instrumentation key , any of them will be sufficient to log the telemetry into App Insight. If, user wants, both the property can be passed as well, it will function in same way.