### PR TITLE
Remove 'bimFileExists' property dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/synchronization-report-react",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "files": [
     "dist"
   ],

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -439,7 +439,7 @@ export const ProblemsTable = ({
   const rowProps = React.useCallback(
     ({
       id,
-      original: { level, fileExists, bimFileExists },
+      original: { level, fileExists },
     }): {
       status?: Status;
       className?: string;
@@ -466,7 +466,7 @@ export const ProblemsTable = ({
           className: `isr-table-row table-row__${isActiveRow ? 'active' : 'inactive'}`,
         };
       } else if (context?.currentTable === TableTypeNames.Files) {
-        return !fileExists && !bimFileExists ? { status: 'negative' } : {};
+        return !fileExists ? { status: 'negative' } : {};
       }
 
       return { status: undefined };

--- a/src/components/ReportTimestamp.tsx
+++ b/src/components/ReportTimestamp.tsx
@@ -73,7 +73,7 @@ export const ReportTimestamp = ({
     return [];
   }, [context?.reportData.sourceFilesInfo, filesProcessed]);
 
-  const processedFilesCount = allFilesProcessed.filter((file) => file.fileExists && file.bimFileExists).length;
+  const processedFilesCount = allFilesProcessed.filter((file) => file.fileExists).length;
 
   return (
     <div className='isr-timestamp-container'>


### PR DESCRIPTION
## Summary
Removes the usage of `bimFileExists` property as it's not required for determining job success/failure status.

## Background
The current implementation incorrectly determines synchronization job success based on both `fileExists` and `bimFileExists` properties. This approach fails for certain integrations where job success should be determined by connector outcome rather than file existence properties.

## Changes
- **ProblemsTable.tsx**: Removed `bimFileExists` from row status logic - now only checks `fileExists` for negative status indication
- **ReportTimestamp.tsx**: Updated processed files count to only consider `fileExists` property

## Related Issues
- Resolves #122